### PR TITLE
Fix issue #1: Improve RemmyChat plugin with new features

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.noximity</groupId>
     <artifactId>remmychat</artifactId>
-    <version>1.1.0</version>
+    <version>1.3.0</version>
     <packaging>jar</packaging>
 
     <name>remmychat</name>
@@ -77,6 +77,12 @@
             <artifactId>placeholderapi</artifactId>
             <version>2.11.6</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>3.45.1.0</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/noximity/remmyChat/RemmyChatPlaceholders.java
+++ b/src/main/java/com/noximity/remmyChat/RemmyChatPlaceholders.java
@@ -1,0 +1,60 @@
+package com.noximity.remmyChat;
+
+import com.noximity.remmyChat.models.ChatUser;
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.OfflinePlayer;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class RemmyChatPlaceholders extends PlaceholderExpansion {
+
+    private final RemmyChat plugin;
+
+    public RemmyChatPlaceholders(RemmyChat plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public @NotNull String getIdentifier() {
+        return "remmychat";
+    }
+
+    @Override
+    public @NotNull String getAuthor() {
+        return String.join(", ", plugin.getDescription().getAuthors());
+    }
+
+    @Override
+    public @NotNull String getVersion() {
+        return plugin.getDescription().getVersion();
+    }
+
+    @Override
+    public boolean persist() {
+        return true; // This is required or else PlaceholderAPI will unregister the expansion on reload
+    }
+
+    @Override
+    public @Nullable String onRequest(OfflinePlayer player, @NotNull String params) {
+        if (player == null) {
+            return "";
+        }
+
+        if (params.equalsIgnoreCase("msgtoggle")) {
+            ChatUser user = plugin.getChatService().getChatUser(player.getUniqueId());
+            return String.valueOf(user.isMsgToggle());
+        }
+
+        if (params.equalsIgnoreCase("socialspy")) {
+            ChatUser user = plugin.getChatService().getChatUser(player.getUniqueId());
+            return String.valueOf(user.isSocialSpy());
+        }
+
+        if (params.equalsIgnoreCase("channel")) {
+            ChatUser user = plugin.getChatService().getChatUser(player.getUniqueId());
+            return user.getCurrentChannel();
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/noximity/remmyChat/commands/MsgToggleCommand.java
+++ b/src/main/java/com/noximity/remmyChat/commands/MsgToggleCommand.java
@@ -1,0 +1,41 @@
+package com.noximity.remmyChat.commands;
+
+import com.noximity.remmyChat.RemmyChat;
+import com.noximity.remmyChat.models.ChatUser;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+public class MsgToggleCommand implements CommandExecutor {
+
+    private final RemmyChat plugin;
+
+    public MsgToggleCommand(RemmyChat plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(plugin.getFormatService().formatSystemMessage("error.players-only"));
+            return true;
+        }
+
+        ChatUser chatUser = plugin.getChatService().getChatUser(player.getUniqueId());
+        boolean newState = !chatUser.isMsgToggle();
+        chatUser.setMsgToggle(newState);
+
+        // Save the new state to the database
+        plugin.getDatabaseManager().saveUserPreferences(chatUser);
+
+        if (newState) {
+            player.sendMessage(plugin.getFormatService().formatSystemMessage("msgtoggle-enabled"));
+        } else {
+            player.sendMessage(plugin.getFormatService().formatSystemMessage("msgtoggle-disabled"));
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/com/noximity/remmyChat/commands/SocialSpyCommand.java
+++ b/src/main/java/com/noximity/remmyChat/commands/SocialSpyCommand.java
@@ -1,0 +1,46 @@
+package com.noximity.remmyChat.commands;
+
+import com.noximity.remmyChat.RemmyChat;
+import com.noximity.remmyChat.models.ChatUser;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+public class SocialSpyCommand implements CommandExecutor {
+
+    private final RemmyChat plugin;
+
+    public SocialSpyCommand(RemmyChat plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(plugin.getFormatService().formatSystemMessage("error.players-only"));
+            return true;
+        }
+
+        if (!player.hasPermission("remmychat.socialspy")) {
+            player.sendMessage(plugin.getFormatService().formatSystemMessage("error.no-permission"));
+            return true;
+        }
+
+        ChatUser chatUser = plugin.getChatService().getChatUser(player.getUniqueId());
+        boolean newState = !chatUser.isSocialSpy();
+        chatUser.setSocialSpy(newState);
+
+        // Save the new state to the database
+        plugin.getDatabaseManager().saveUserPreferences(chatUser);
+
+        if (newState) {
+            player.sendMessage(plugin.getFormatService().formatSystemMessage("socialspy-enabled"));
+        } else {
+            player.sendMessage(plugin.getFormatService().formatSystemMessage("socialspy-disabled"));
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/com/noximity/remmyChat/database/DatabaseManager.java
+++ b/src/main/java/com/noximity/remmyChat/database/DatabaseManager.java
@@ -1,0 +1,110 @@
+package com.noximity.remmyChat.database;
+
+import com.noximity.remmyChat.RemmyChat;
+import com.noximity.remmyChat.models.ChatUser;
+import org.bukkit.Bukkit;
+
+import java.io.File;
+import java.sql.*;
+import java.util.UUID;
+import java.util.logging.Level;
+
+public class DatabaseManager {
+
+    private final RemmyChat plugin;
+    private Connection connection;
+    private final String dbName = "remmychat.db";
+
+    public DatabaseManager(RemmyChat plugin) {
+        this.plugin = plugin;
+        this.initialize();
+    }
+
+    private void initialize() {
+        File dataFolder = new File(plugin.getDataFolder(), dbName);
+        if (!dataFolder.exists()) {
+            try {
+                plugin.getDataFolder().mkdir();
+            } catch (Exception e) {
+                plugin.getLogger().log(Level.SEVERE, "Failed to create plugin data folder", e);
+            }
+        }
+
+        try {
+            Class.forName("org.sqlite.JDBC");
+            connection = DriverManager.getConnection("jdbc:sqlite:" + dataFolder);
+
+            createTables();
+            plugin.getLogger().info("SQLite database connection established!");
+        } catch (SQLException | ClassNotFoundException e) {
+            plugin.getLogger().log(Level.SEVERE, "Failed to initialize SQLite database", e);
+        }
+    }
+
+    private void createTables() {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("CREATE TABLE IF NOT EXISTS users (" +
+                    "uuid VARCHAR(36) PRIMARY KEY, " +
+                    "msg_toggle BOOLEAN DEFAULT 1, " +
+                    "social_spy BOOLEAN DEFAULT 0)");
+
+            plugin.getLogger().info("Database tables created or already exist");
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, "Failed to create database tables", e);
+        }
+    }
+
+    public void close() {
+        try {
+            if (connection != null && !connection.isClosed()) {
+                connection.close();
+                plugin.getLogger().info("Database connection closed");
+            }
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, "Failed to close database connection", e);
+        }
+    }
+
+    public void saveUserPreferences(ChatUser user) {
+        // Run asynchronously if the plugin is enabled, otherwise run synchronously
+        if (plugin.isEnabled()) {
+            Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+                saveUserPreferencesSync(user);
+            });
+        } else {
+            saveUserPreferencesSync(user);
+        }
+    }
+
+    private void saveUserPreferencesSync(ChatUser user) {
+        try (PreparedStatement ps = connection.prepareStatement(
+                "INSERT OR REPLACE INTO users (uuid, msg_toggle, social_spy) VALUES (?, ?, ?)")) {
+            ps.setString(1, user.getUuid().toString());
+            ps.setBoolean(2, user.isMsgToggle());
+            ps.setBoolean(3, user.isSocialSpy());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, "Failed to save user preferences", e);
+        }
+    }
+
+    public ChatUser loadUserPreferences(UUID uuid, String defaultChannel) {
+        try (PreparedStatement ps = connection.prepareStatement(
+                "SELECT msg_toggle, social_spy FROM users WHERE uuid = ?")) {
+            ps.setString(1, uuid.toString());
+
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    boolean msgToggle = rs.getBoolean("msg_toggle");
+                    boolean socialSpy = rs.getBoolean("social_spy");
+                    return new ChatUser(uuid, defaultChannel, msgToggle, socialSpy);
+                }
+            }
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, "Failed to load user preferences", e);
+        }
+
+        // Return default user if not found in database
+        return new ChatUser(uuid, defaultChannel);
+    }
+}

--- a/src/main/java/com/noximity/remmyChat/models/ChatUser.java
+++ b/src/main/java/com/noximity/remmyChat/models/ChatUser.java
@@ -7,10 +7,21 @@ public class ChatUser {
     private final UUID uuid;
     private String currentChannel;
     private UUID lastMessagedPlayer;
+    private boolean msgToggle;
+    private boolean socialSpy;
 
     public ChatUser(UUID uuid, String defaultChannel) {
         this.uuid = uuid;
         this.currentChannel = defaultChannel;
+        this.msgToggle = true;
+        this.socialSpy = false;
+    }
+
+    public ChatUser(UUID uuid, String defaultChannel, boolean msgToggle, boolean socialSpy) {
+        this.uuid = uuid;
+        this.currentChannel = defaultChannel;
+        this.msgToggle = msgToggle;
+        this.socialSpy = socialSpy;
     }
 
     public UUID getUuid() {
@@ -31,5 +42,21 @@ public class ChatUser {
 
     public void setLastMessagedPlayer(UUID lastMessagedPlayer) {
         this.lastMessagedPlayer = lastMessagedPlayer;
+    }
+
+    public boolean isMsgToggle() {
+        return msgToggle;
+    }
+
+    public void setMsgToggle(boolean msgToggle) {
+        this.msgToggle = msgToggle;
+    }
+
+    public boolean isSocialSpy() {
+        return socialSpy;
+    }
+
+    public void setSocialSpy(boolean socialSpy) {
+        this.socialSpy = socialSpy;
     }
 }

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -10,6 +10,13 @@ cooldown: "<#D0021B>Please wait <seconds> seconds before chatting again.</#D0021
 # Private messages
 msg-to-format: "<#778899>To <#5BC0DE><player></#5BC0DE>: <#F8F9FA><message></#F8F9FA></#778899>"
 msg-from-format: "<#778899>From <#5BC0DE><player></#5BC0DE>: <#F8F9FA><message></#F8F9FA></#778899>"
+socialspy-format: "<#A9A9A9>[Spy] <#5BC0DE><sender></#5BC0DE> → <#5BC0DE><receiver></#5BC0DE>: <#F8F9FA><message></#F8F9FA></#A9A9A9>"
+
+# Toggle messages
+msgtoggle-enabled: "<#5BC0DE>You have enabled private messages.</#5BC0DE>"
+msgtoggle-disabled: "<#5BC0DE>You have disabled private messages.</#5BC0DE>"
+socialspy-enabled: "<#5BC0DE>You have enabled social spy mode.</#5BC0DE>"
+socialspy-disabled: "<#5BC0DE>You have disabled social spy mode.</#5BC0DE>"
 
 # Help messages
 help-header: "<#4A90E2>┌─── <#5BC0DE>RemmyChat Help</#5BC0DE> ───┐</#4A90E2>"
@@ -28,3 +35,5 @@ error:
   msg-usage: "<#D0021B>Usage: /msg <player> <message></#D0021B>"
   nobody-to-reply: "<#D0021B>You have nobody to reply to.</#D0021B>"
   player-not-online: "<#D0021B>The player you were messaging is no longer online.</#D0021B>"
+  reply-usage: "<#D0021B>Usage: /reply <message></#D0021B>"
+  player-messages-disabled: "<#D0021B><player> has disabled private messages.</#D0021B>"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -27,6 +27,18 @@ commands:
     aliases: [r]
     permission: remmychat.msg
 
+  msgtoggle:
+    description: Toggle private messages on or off
+    usage: /msgtoggle
+    aliases: [togglemsg, togglepm]
+    permission: remmychat.msgtoggle
+
+  socialspy:
+    description: Toggle social spy mode to see private messages
+    usage: /socialspy
+    aliases: [msgspy, spy]
+    permission: remmychat.socialspy
+
 permissions:
   remmychat.use:
     description: Allows using the basic plugin commands
@@ -35,6 +47,18 @@ permissions:
   remmychat.msg:
     description: Allows sending private messages
     default: true
+
+  remmychat.msgtoggle:
+    description: Allows toggling private messages on/off
+    default: true
+
+  remmychat.msgtoggle.bypass:
+    description: Allows bypassing other players' message toggle
+    default: op
+
+  remmychat.socialspy:
+    description: Allows using the social spy feature
+    default: op
 
   remmychat.admin:
     description: Allows using administrative commands


### PR DESCRIPTION
- Add /msgtoggle command to allow players to toggle private messages on/off
- Add /socialspy command for staff to monitor private messages
- Fix /reply command to show proper usage message
- Include player's own name in /msg tab completion
- Add SQLite database support for persistent user preferences
- Add PlaceholderAPI integration with %remmychat_msgtoggle%, %remmychat_socialspy%, and %remmychat_channel% placeholders

Closes #1