### PR TITLE
Fix console chat logging and improve empty message handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,145 @@
+# RemmyChat
+
 **RemmyChat** is a lightweight, feature-rich chat management solution for PaperMC servers that enhances player communication with a clean, modern design.
 
-![](https://cdn.modrinth.com/data/kcImu7Wi/images/75ae522ff749334639ce6184a3e2e22d92e9e991.jpeg)
+<img src="https://img.shields.io/badge/API-1.21-blue" alt="API Version"> <img src="https://img.shields.io/badge/Version-1.4.2-green" alt="Version"> <img src="https://img.shields.io/badge/License-GPL--3.0-orange" alt="License">
+
+## Overview
+
+RemmyChat transforms your server's communication with a sleek, modern interface while providing powerful customization through MiniMessage formatting. From immersive proximity chat to comprehensive anti-spam features, RemmyChat balances simplicity with functionality to create the perfect chat experience.
 
 ## Features
-- **Full MiniMessage Support** - Rich text formatting with colors, hover effects, and clickable elements
-- **Multiple Chat Channels** - Global, local, staff, and trade channels with customizable formats
-- **Proximity Chat** - Configure radius-based local chat for immersive gameplay
-- **PlaceholderAPI Integration** - Unlimited customization possibilities
-- **Private Messaging** - Seamless player-to-player communication with reply functionality
-- **Interactive Elements** - Hoverable player names with information tooltips
-- **Smart URL Detection** - Automatic link formatting with click-to-open
-- **Anti-Spam** - Configurable chat cooldown system
-- **Optimized Performance** - Minimal resource usage even on busy servers
+
+- **Advanced MiniMessage Formatting** — Rich text with colors, gradients, hover effects, and clickable elements
+- **Multi-Channel System** — Global, local, staff, and trade channels with completely customizable formats
+- **Proximity Chat** — Configurable radius-based local chat for immersive gameplay
+- **Private Messaging System** — Seamless player-to-player communication with reply functionality
+- **Message Toggle** — Allow players to enable/disable private messages
+- **Social Spy** — Staff monitoring of player private messages
+- **Flexible Permission System** — Granular control over all plugin features and channels
+- **Group-Based Formatting** — Different chat formats based on player permissions
+- **Custom Placeholders** — Create reusable text elements for consistency across formats
+- **Template System** — Hover templates, channel prefixes, and name styles for easy configuration
+- **Interactive Elements** — Hoverable player names with customizable information tooltips
+- **Automatic URL Detection** — Link formatting with configurable click-to-open functionality
+- **Chat Cooldown** — Configurable anti-spam system to prevent message flooding
+- **Message Persistence** — Database storage for player preferences and chat history
+- **PlaceholderAPI Integration** — Unlimited customization possibilities
+- **LuckPerms Integration** — Seamless permission management
+- **Optimized Performance** — Minimal resource usage even on busy servers
+
+## Getting Started
+
+Installation is straightforward:
+
+1. Download the latest RemmyChat release
+2. Place the JAR file in your server's `plugins` folder
+3. Restart your server
+4. Configuration files will be generated automatically
+
+## Configuration
+
+RemmyChat's configuration is highly flexible while remaining intuitive. Here's a sample of what you can accomplish:
+
+### Channel Configuration
+
+```yaml
+# Channel configurations
+channels:
+  global:
+    permission: "" # Empty means everyone can use
+    radius: -1     # -1 means global chat
+    prefix: ""     # No prefix for global
+    hover: "player-info"
+    display-name: ""
+
+  local:
+    permission: "remmychat.channel.local"
+    radius: 100    # Chat radius in blocks
+    prefix: "local" 
+    hover: "local-chat"
+    display-name: "<gray>[Local]</gray>"
+
+  staff:
+    permission: "remmychat.channel.staff"
+    radius: -1
+    prefix: "staff"
+    hover: "staff-chat"
+    display-name: "<gold>[Staff]</gold>"
+```
+
+### Custom Formatting
+
+```yaml
+# Group-based formatting with customizable styles
+groups:
+  admin:
+    name-style: "admin"
+    prefix: ""
+    format: "%admin-hover% %player_name%: %default-message%"
+
+  vip:
+    name-style: "vip"
+    prefix: ""
+    format: "<click:suggest_command:'/msg %player_name%'><hover:show_text:'VIP Player'>%vip-prefix%</hover></click> %player_name%: %default-message%"
+```
+
+### Interactive Templates
+
+```yaml
+# Templates for reuse across formats
+templates:
+  hovers:
+    player-info: "<#778899>Player information\n<#F8F9FA>Name: <#E8E8E8>%player_name%\n<#F8F9FA>Click to message"
+    
+  name-styles:
+    default: "<#4A90E2>%player_name%"
+    owner: "<bold><gradient:#FF0000:#FFAA00>%player_name%</gradient></bold>"
+    admin: "<italic><color:#CC44FF>%player_name%</color></italic>"
+```
+
+## Commands
+
+| Command | Description | Permission |
+|---------|-------------|------------|
+| `/remchat channel <name>` | Switch between chat channels | `remmychat.use` |
+| `/remchat reload` | Reload plugin configuration | `remmychat.admin` |
+| `/msg <player> <message>` | Send private message | `remmychat.msg` |
+| `/reply <message>` | Reply to last private message | `remmychat.msg` |
+| `/msgtoggle` | Toggle receiving private messages | `remmychat.msgtoggle` |
+| `/socialspy` | Monitor private messages between players | `remmychat.socialspy` |
+
+## Permissions
+
+| Permission | Description | Default |
+|------------|-------------|---------|
+| `remmychat.use` | Basic plugin access | `true` |
+| `remmychat.msg` | Send private messages | `true` |
+| `remmychat.msgtoggle` | Toggle private messages | `true` |
+| `remmychat.msgtoggle.bypass` | Bypass message toggle | `op` |
+| `remmychat.socialspy` | Use social spy feature | `op` |
+| `remmychat.admin` | Administrative access | `op` |
+| `remmychat.channel.<name>` | Access to specific channel | Varies |
+
+## Integration
+
+### PlaceholderAPI
+
+RemmyChat automatically integrates with PlaceholderAPI if installed, allowing you to use any placeholders in your chat formats.
+
+### LuckPerms
+
+When LuckPerms is detected, RemmyChat can use permission groups for chat formatting, simplifying setup for servers with existing permission structures.
 
 ## Why Choose RemmyChat?
-RemmyChat stands out with its perfect balance of simplicity and functionality. The plugin is designed with both server administrators and players in mind - easy to configure yet highly customizable, with a beautiful interface that enhances communication while staying out of the way.
 
-![](https://cdn.modrinth.com/data/kcImu7Wi/images/154da5ba69d238aab11a09bb1c795b9e76e24edc.jpeg)
-![](https://cdn.modrinth.com/data/kcImu7Wi/images/48e4546417fe67875a2507bde87e93be6a266198.jpeg)
-## Getting Started
-Installation is straightforward - just drop the plugin in your server's plugins folder, restart, and you're ready to go! Default configuration works great out of the box, but you can easily customize every aspect to match your server's unique needs.
+RemmyChat stands out with its perfect balance of simplicity and functionality. The plugin is designed with both server administrators and players in mind - easy to configure yet highly customizable, with a beautiful interface that enhances communication while staying out of the way.
 
 Whether you're running a small community server or a large network, RemmyChat offers the flexibility, performance, and sleek design to elevate your chat experience.
 
-![](https://cdn.modrinth.com/data/kcImu7Wi/images/0bc10892409d760a930051b76e2047756263c0c2.jpeg)
-### Commands
-- `/remchat channel <name>` - Switch between chat channels
-- `/msg <player> <message>` - Send private messages
-- `/reply <message>` - Reply to the last private message
+## Support & Development
 
-### Permissions
-- `remmychat.use` - Access to basic commands
-- `remmychat.channel.<channelname>` - Access to specific channels
-- `remmychat.admin` - Administrative access
-
-![](https://cdn.modrinth.com/data/kcImu7Wi/images/1155be08ccbcc31c638d9daedcc38b8e581c200e.jpeg)
+- **Website**: [noximity.com](https://noximity.com)  
+- **Issues & Feature Requests**: Please use our GitHub issues tracker
+- **Version**: 1.4.1
+- **License**: GPL-3.0

--- a/src/main/java/com/noximity/remmyChat/commands/MsgToggleCommand.java
+++ b/src/main/java/com/noximity/remmyChat/commands/MsgToggleCommand.java
@@ -2,6 +2,7 @@ package com.noximity.remmyChat.commands;
 
 import com.noximity.remmyChat.RemmyChat;
 import com.noximity.remmyChat.models.ChatUser;
+import net.kyori.adventure.text.Component;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -31,9 +32,15 @@ public class MsgToggleCommand implements CommandExecutor {
         plugin.getDatabaseManager().saveUserPreferences(chatUser);
 
         if (newState) {
-            player.sendMessage(plugin.getFormatService().formatSystemMessage("msgtoggle-enabled"));
+            Component message = plugin.getFormatService().formatSystemMessage("msgtoggle-enabled");
+            if (message != null) {
+                player.sendMessage(message);
+            }
         } else {
-            player.sendMessage(plugin.getFormatService().formatSystemMessage("msgtoggle-disabled"));
+            Component message = plugin.getFormatService().formatSystemMessage("msgtoggle-disabled");
+            if (message != null) {
+                player.sendMessage(message);
+            }
         }
 
         return true;

--- a/src/main/java/com/noximity/remmyChat/listeners/ChatListener.java
+++ b/src/main/java/com/noximity/remmyChat/listeners/ChatListener.java
@@ -76,6 +76,10 @@ public class ChatListener implements Listener {
         // Format the message
         Component formattedMessage = plugin.getFormatService().formatChatMessage(player, currentChannel.getName(), rawMessage);
 
+        // Log the message to console
+        String plainMessage = net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer.plainText().serialize(formattedMessage);
+        plugin.getLogger().info(plainMessage);
+
         // Determine who should receive the message
         if (currentChannel.getRadius() > 0) {
             // Local radius-based chat - only players within radius receive the message

--- a/src/main/java/com/noximity/remmyChat/services/FormatService.java
+++ b/src/main/java/com/noximity/remmyChat/services/FormatService.java
@@ -333,6 +333,12 @@ public class FormatService {
 
     public Component formatSystemMessage(String path, TagResolver... placeholders) {
         String message = plugin.getMessages().getMessage(path);
+
+        // Skip empty messages completely by returning null
+        if (message == null || message.trim().isEmpty()) {
+            return null;
+        }
+
         try {
             return miniMessage.deserialize(message, TagResolver.resolver(placeholders));
         } catch (Exception e) {


### PR DESCRIPTION
CHANGES:
- Add console logging for regular chat messages (issue #10)
- Prevent display of empty messages when set to ""
- Update message handling to skip null messages completely

Previously, only private messages were logged to console and empty messages would show as blank lines in the chat. Now all chat messages appear in the console log, and empty messages are completely skipped when configured as empty strings in messages.yml.

Closes #10